### PR TITLE
Hydrowood pinned&grouped count

### DIFF
--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Разработчик"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Да се броят ли фиксираните табове"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Да се броят ли групираните табове"
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Vývojář"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Počítat s připnutými kartami"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Počítat se seskupenými kartami"
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Udvikler"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Skal fastgjorte faner tælles med"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Skal grupperede faner tælles med"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Developer"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Sollen angeheftete Tabs gezählt werden"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Sollen gruppierte Tabs gezählt werden"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Προγραμματιστής"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Να συμπεριληφθούν οι επισημασμένες καρτέλες"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Να συμπεριληφθούν οι ομαδοποιημένες καρτέλες"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -46,5 +46,13 @@
 
   "string_10": {
     "message": "Developer"
+  },
+
+  "string_for_countPinnedTabs": {
+    "message": "count pinned tabs"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "count grouped tabs"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Desarrollador"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "¿Contar pestañas ancladas"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "¿Contar pestañas agrupadas"
   }
 }

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Arendaja"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Kas arvesse võetakse kinnitatud kaardid"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Kas arvesse võetakse rühmitatud kaardid"
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Kehittäjä"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Lasketaanko kiinnitetyt välilehdet mukaan"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Lasketaanko ryhmitellyt välilehdet mukaan"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Développeur"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Faut-il compter les onglets épinglés "
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Faut-il compter les onglets groupés"
   }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Fejlesztő"
+  },
+  "string_for_countPinnedTabs": {
+    "message": " Számítsa a rögzített lapokat"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Számítsa a csoportosított lapokat"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Sviluppatore"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Calcolare le schede fisse"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Calcolare le schede raggruppate"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "開発者"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "固定されたタブを計算しますか"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "グループ化されたタブを計算しますか"
   }
 }

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Izstrādātājs"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Vai aprēķināt fiksētās cilnes"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Vai aprēķināt grupētās cilnes"
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Ontwikkelaar"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Berekent u de vastgezette tabbladen"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Berekent u de gegroepeerde tabbladen"
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Deweloper"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Czy obliczać zakotwiczone karty"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Czy obliczać karty zgrupowane"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Desenvolvedor"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Calcular as guias fixas"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Calcular as guias agrupadas"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Разработчик"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Рассчитать закрепленные вкладки"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Рассчитать группированные вкладки"
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -46,5 +46,12 @@
 
   "string_10": {
     "message": "Utvecklare"
+  },
+  "string_for_countPinnedTabs": {
+    "message": "Beräkna fästa flikar"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "Beräkna grupperade flikar"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -46,5 +46,13 @@
 
   "string_10": {
     "message": "开发商"
+  },
+
+  "string_for_countPinnedTabs": {
+    "message": "是否计算已固定标签页"
+  },
+
+  "string_for_countGroupedTabs": {
+    "message": "是否计算已分组标签页"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "author": "Fernando Mireles & Hydrowood",
   "homepage_url": "https://github.com/fernandomireles/allowed-tabs",
 
@@ -24,7 +24,12 @@
   "permissions": [
     "storage",
     "tabs",
-    "tabGroups"
+    "tabGroups",
+    "activeTab", 
+    "scripting"
+  ],
+  "host_permissions": [
+    "<all_urls>"
   ],
   "web_accessible_resources": [
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,30 +1,35 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
 
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "0.1.1",
-  "author": "Fernando Mireles",
-	"homepage_url": "https://github.com/fernandomireles/allowed-tabs",
+  "version": "0.2.1",
+  "author": "Fernando Mireles & Hydrowood",
+  "homepage_url": "https://github.com/fernandomireles/allowed-tabs",
 
   "background": {
-	"scripts": ["static/background.js"]
+    "service_worker": "static/background.js"
   },
   "icons": {
     "16": "static/icon-16.png",
     "48": "static/icon-48.png",
     "128": "static/icon-128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "static/icon-small.png",
     "default_popup": "static/options.html"
   },
   "options_page": "static/options.html",
   "permissions": [
-    "storage"
+    "storage",
+    "tabs",
+    "tabGroups"
   ],
   "web_accessible_resources": [
-    "static/icon-small.png", "static/icon.png"
+    {
+      "resources": ["static/icon-small.png", "static/icon.png"],
+      "matches": ["<all_urls>"]
+    }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Fernando Mireles & Hydrowood",
   "homepage_url": "https://github.com/fernandomireles/allowed-tabs",
 

--- a/static/background.js
+++ b/static/background.js
@@ -1,8 +1,9 @@
 const browser = chrome || browser
 
 const tabQuery = (options, params = {}) => new Promise(res => {
-	if (!options.countPinnedTabs) params.pinned = false
-	browser.tabs.query(params, tabs => res(tabs))
+    if (!options.countPinnedTabs) params.pinned = false
+    if (!options.countGroupedTabs) params.groupId = browser.tabGroups.TAB_GROUP_ID_NONE
+    browser.tabs.query(params, tabs => res(tabs))
 })
 
 const windowRemaining = options =>
@@ -15,17 +16,17 @@ const totalRemaining = options =>
 
 const updateBadge = options => {
 	if (!options.displayBadge) {
-		browser.browserAction.setBadgeText({
+		browser.action.setBadgeText({
 		text: "" })
 		return;
 	}
 
 	Promise.all([windowRemaining(options), totalRemaining(options)])
 	.then(remaining => {
-		browser.browserAction.setBadgeText({
+		browser.action.setBadgeText({
 			text: Math.min(...remaining).toString()
 		});
-		chrome.browserAction.setBadgeBackgroundColor({
+		chrome.action.setBadgeBackgroundColor({
 			color: "#7e7e7e"
 		})
 	})
@@ -146,6 +147,7 @@ const app = {
 				exceedTabNewWindow: false,
 				displayAlert: true,
 				countPinnedTabs: false,
+				countGroupedTabs: false, // added
 				displayBadge: true,
 				alertMessage: chrome.i18n.getMessage("string_7")
 			}

--- a/static/background.js
+++ b/static/background.js
@@ -53,36 +53,57 @@ const getOptions = () => new Promise((res, rej) => {
 		})
 	})
 })
-
-const displayAlert = (options, place) => new Promise((res, rej) => {
-	if (!options.displayAlert) { return res(false) }
-
-	const replacer = (match, p1, offset, string) => {
-		switch (p1) {
-			case "place":
-			case "which":
-				return place === "window" ?
-					"one window" : "total";
-				break;
-
-			case "maxPlace":
-			case "maxWhich":
-				return options[
-					"max" + capitalizeFirstLetter(place)
-				];
-				break;
-
-			default:
-				return options[p1] || "?";
-		}
-	};
-
-	const renderedMessage = options.alertMessage.replace(
-		/{\s*(\S+)\s*}/g,
-		replacer
-	)
-	alert(renderedMessage);
-})
+const displayAlert = (options, place) => {
+    return new Promise((res, rej) => {
+		if (!options.displayAlert) { return res(false) }
+		const replacer = (match, p1, offset, string) => {
+			switch (p1) {
+				case "place":
+				case "which":
+					return place === "window" ?
+						"one window" : "total";
+					break;
+	
+				case "maxPlace":
+				case "maxWhich":
+					return options[
+						"max" + capitalizeFirstLetter(place)
+					];
+					break;
+	
+				default:
+					return options[p1] || "?";
+			}
+		};
+	
+		const renderedMessage = options.alertMessage.replace(
+			/{\s*(\S+)\s*}/g,
+			replacer
+		)
+		console.log( renderedMessage)
+		// fix: alert(confirm) dialog not working 
+		chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+			chrome.scripting.executeScript({
+				target: {tabId: tabs[0].id},
+				function: function(message) {
+					return new Promise((resolve, reject) => {
+						const result = window.confirm(message);
+						resolve(result);
+					});
+				},
+				args: [renderedMessage]  // pass renderedMessage as args 
+			}, function(results) {
+				if (chrome.runtime.lastError) {
+					console.error(chrome.runtime.lastError);
+				} else if (results && results.length > 0) {
+					res(results[0].result);
+				} else {
+					rej('No result from confirm dialog');
+				}
+			});
+		});
+    });
+}
 
 let tabCount = -1
 let previousTabCount = -1
@@ -123,18 +144,22 @@ const handleTabCreated = tab => options => {
 			return;
 		}
 		console.log("amountOfTabsCreated", amountOfTabsCreated)
-		displayAlert(options, place)
-		if (amountOfTabsCreated === 1) {
-			handleExceedTabs(tab, options, place);
-			app.update()
-		} else if (amountOfTabsCreated > 1) {
-			passes = amountOfTabsCreated - 1
-		} else if (amountOfTabsCreated === -1) {
-			handleExceedTabs(tab, options, place);
-			app.update()
-		} else {
-			throw new Error("weird: multiple tabs closed after tab created")
-		}
+
+		// fix: wait displayAlert Promise
+		return displayAlert(options, place)  
+		.then(() => {
+			if (amountOfTabsCreated === 1) {
+				handleExceedTabs(tab, options, place);
+				app.update()
+			} else if (amountOfTabsCreated > 1) {
+				passes = amountOfTabsCreated - 1
+			} else if (amountOfTabsCreated === -1) {
+				handleExceedTabs(tab, options, place);
+				app.update()
+			} else {
+				throw new Error("weird: multiple tabs closed after tab created")
+			}
+		});
 	}))
 }
 

--- a/static/managerLanguage.js
+++ b/static/managerLanguage.js
@@ -1,3 +1,5 @@
+let browsers = window.chrome || window.browser;
+
 function localizeHtmlPage()
 {
     //Localize by replacing __MSG_***__ meta tags
@@ -9,7 +11,7 @@ function localizeHtmlPage()
         var valStrH = obj.innerHTML.toString();
         var valNewH = valStrH.replace(/__MSG_(\w+)__/g, function(match, v1)
         {
-            return v1 ? chrome.i18n.getMessage(v1) : "";
+            return v1 ? browsers.i18n.getMessage(v1) : "";
         });
 
         if(valNewH != valStrH)

--- a/static/options.css
+++ b/static/options.css
@@ -21,7 +21,8 @@ body {
 .header {
 	background-color: #FFDF01;
 	color: black;
-	width: 200px;
+    min-width: 200px;
+    max-width: 100%;  /* or any other value you prefer */
 	height: 5px;
 	display: table-cell;
     vertical-align: middle;

--- a/static/options.html
+++ b/static/options.html
@@ -62,6 +62,30 @@
 		</div>
 		</div>
 
+		<!-- Button for countPinnedTabs -->
+		<div class="parent">
+		<div class="specs">
+			<label class="switch">
+			<input id="countPinnedTabs" type="checkbox">
+			<span class="slider round"></span>
+		</div>
+		<div class="specs2">
+			<label for="countPinnedTabs" id="countPinnedTabsLabel">__MSG_string_for_countPinnedTabs__</label>
+		</div>
+		</div>
+
+		<!-- Button for countGroupedTabs -->
+		<div class="parent">
+		<div class="specs">
+			<label class="switch">
+			<input id="countGroupedTabs" type="checkbox">
+			<span class="slider round"></span>
+		</div>
+		<div class="specs2">
+			<label for="countGroupedTabs" id="countGroupedTabsLabel">__MSG_string_for_countGroupedTabs__</label>
+		</div>
+		</div>
+
 		<!-- Place to write the alert message -->
 		<input id="alertMessage" type="text">
 

--- a/static/options.html
+++ b/static/options.html
@@ -62,28 +62,30 @@
 		</div>
 		</div>
 
-		<!-- Button for countPinnedTabs -->
+		<!-- Count for countPinnedTabs -->
 		<div class="parent">
-		<div class="specs">
-			<label class="switch">
-			<input id="countPinnedTabs" type="checkbox">
-			<span class="slider round"></span>
-		</div>
-		<div class="specs2">
-			<label for="countPinnedTabs" id="countPinnedTabsLabel">__MSG_string_for_countPinnedTabs__</label>
-		</div>
+			<div class="specs">
+				<label class="switch">
+				<input id="countPinnedTabs" type="checkbox">
+				<span class="slider round"></span>
+			</div>
+			<div class="specs2">
+				<label for="countPinnedTabs" id="countPinnedTabsLabel">__MSG_string_for_countPinnedTabs__</label>
+				<span id="pinnedTabsCount"></span>
+			</div>
 		</div>
 
-		<!-- Button for countGroupedTabs -->
+		<!-- Count for countGroupedTabs -->
 		<div class="parent">
-		<div class="specs">
-			<label class="switch">
-			<input id="countGroupedTabs" type="checkbox">
-			<span class="slider round"></span>
-		</div>
-		<div class="specs2">
-			<label for="countGroupedTabs" id="countGroupedTabsLabel">__MSG_string_for_countGroupedTabs__</label>
-		</div>
+			<div class="specs">
+				<label class="switch">
+				<input id="countGroupedTabs" type="checkbox">
+				<span class="slider round"></span>
+			</div>
+			<div class="specs2">
+				<label for="countGroupedTabs" id="countGroupedTabsLabel">__MSG_string_for_countGroupedTabs__</label>
+				<span id="groupedTabsCount"></span>
+			</div>
 		</div>
 
 		<!-- Place to write the alert message -->

--- a/static/options.js
+++ b/static/options.js
@@ -1,9 +1,11 @@
 const browser = chrome || browser
-
 const tabQuery = (options, params = {}) => new Promise(res => {
-	if (!options.countPinnedTabs) params.pinned = false
-	browser.tabs.query(params, tabs => res(tabs))
+    if (!options.countPinnedTabs) params.pinned = false
+    if (!options.countGroupedTabs) params.groupId = chrome.tabGroups.TAB_GROUP_ID_NONE
+    browser.tabs.query(params, tabs => res(tabs))
 })
+
+// tabQuery({countPinnedTabs: false, countGroupedTabs: false})
 
 const windowRemaining = options =>
 	tabQuery(options, { currentWindow: true })
@@ -15,13 +17,13 @@ const totalRemaining = options =>
 
 const updateBadge = options => {
 	if (!options.displayBadge) {
-		browser.browserAction.setBadgeText({ text: "" })
+		browser.action.setBadgeText({ text: "" })
 		return;
 	}
 
 	Promise.all([windowRemaining(options), totalRemaining(options)])
 	.then(remaining => {
-		browser.browserAction.setBadgeText({
+		browser.action.setBadgeText({
 			text: Math.min(...remaining).toString()
 		})
 	})

--- a/static/options.js
+++ b/static/options.js
@@ -1,7 +1,7 @@
 const browser = chrome || browser
 const tabQuery = (options, params = {}) => new Promise(res => {
-    if (!options.countPinnedTabs) params.pinned = false
-    if (!options.countGroupedTabs) params.groupId = chrome.tabGroups.TAB_GROUP_ID_NONE
+	if (!options.countPinnedTabs && params.pinned === undefined) params.pinned = false
+    if (!options.countGroupedTabs && params.groupId === undefined) params.groupId = browser.tabGroups.TAB_GROUP_ID_NONE
     browser.tabs.query(params, tabs => res(tabs))
 })
 
@@ -53,11 +53,10 @@ const saveOptions = () => {
 
 		const status = document.getElementById('status');
 		status.className = 'notice';
-		status.textContent = chrome.i18n.getMessage("string_9");
+		status.textContent = browser.i18n.getMessage("string_9");
 		setTimeout(() => {
 			status.className += ' invisible';
 		}, 100);
-
 
 		updateBadge(options)
 	});
@@ -77,6 +76,9 @@ const restoreOptions = () => {
 
 				input[valueType] = options[input.id];
 			};
+		
+		document.getElementById('pinnedTabsCount').innerText = options.pinnedTabsCount;
+		document.getElementById('groupedTabsCount').innerText = options.groupedTabsCount;
 		});
 	});
 }


### PR DESCRIPTION
1.all localized 
2.change all chrome. to chrome.||browser. fitting firefox(no test yet)
3.change window.alert to window.confirm (some URL like chrome:// and extension store, as well as switching active tabs will not show window.confirm window and close immediately tab )
4.some errors is uncaught or showing up, but don't affect the extension's function


Your version also doesn't have the ability to close about:blank tabs by extension after the tab limit is exceeded, which means that users can create unlimited about:blanks in the latest versions of browsers anyway. trying to block it in manifestV3 results in  Error: Cannot remove NTP tabs. So I don't think the inability to limit about:blank tabs is a bug.
