### PR TITLE
Groupslimit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
 
 ## Changelog
 
+`2024-05`
+- Forcing an upper limit on the number of tag groups
+
+`2024-02`
+- Add pinned & grouped support(only locale in en & zh-CN)
+- Update Manifest to V3.
+- change all "chrome." to "chrome.||browser." to fit Firefox(no test yet)
+- change "window.alert" to "window.confirm" (some URL like chrome:// and extension store, as well as switching active tabs won't show confirm window and close tab immediately)
+- some errors is uncaught or showing up, but don't affect the extension's function
+
 `2021-07`
 
 Features:

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@
 [Install it directly from the Microsoft Store](https://microsoftedge.microsoft.com/addons/detail/bedgmdmofacooedgglodglabbelmekha).
 
 ## Changelog
-`2024-07-todo`
-- 能开关同时显示多少个剩余标签和组的开关
-- drag有bug!会导致我排序标签页的时候出问题,UI不更新
 
 `2024-06`
 - Fix extension's collapse after draging while handling exceeded tag(mainly caused by touchpad).

--- a/README.md
+++ b/README.md
@@ -17,15 +17,24 @@
 [Install it directly from the Microsoft Store](https://microsoftedge.microsoft.com/addons/detail/bedgmdmofacooedgglodglabbelmekha).
 
 ## Changelog
+`2024-07-todo`
+- 能开关同时显示多少个剩余标签和组的开关
+- drag有bug!会导致我排序标签页的时候出问题,UI不更新
+
+`2024-06`
+- Fix extension's collapse after draging while handling exceeded tag(mainly caused by touchpad).
+- Add 2 buttons about tab groups. 
+- only tested via Edge, never via Chrome （cannot work in Firefox bcz serverworker is not supported in Firefox）.  
 
 `2024-05`
-- Forcing an upper limit on the number of tag groups
+- Forcing an upper limit on the number of tag groups.
+- Auto-collapse any other groups when focous on one group.
 
 `2024-02`
-- Add pinned & grouped support(only locale in en & zh-CN)
+- Add pinned & grouped support
 - Update Manifest to V3.
-- change all "chrome." to "chrome.||browser." to fit Firefox(no test yet)
-- change "window.alert" to "window.confirm" (some URL like chrome:// and extension store, as well as switching active tabs won't show confirm window and close tab immediately)
+- Change all "chrome." to "chrome.||browser." to fit Firefox(no test yet)
+- Change "window.alert" to "window.confirm" (some URL like chrome:// and extension store, as well as switching active tabs won't show confirm window and close tab immediately)
 - some errors is uncaught or showing up, but don't affect the extension's function
 
 `2021-07`

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Максимален брой групи етикети"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Ограничаване на общия брой групи маркери?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Да се ​​разшири ли само една група раздели едновременно?"
   }
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Да се броят ли групираните табове"
+  },
+  "string_for_groupsLimit": {
+    "message": "Максимален брой групи етикети"
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maximální počet skupin značek"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Omezit celkový počet skupin značek?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Rozbalit pouze jednu skupinu karet současně?"
   }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Počítat se seskupenými kartami"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maximální počet skupin značek"
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maksimalt antal taggrupper"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Vil du begrænse det samlede antal taggrupper?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Vil du kun udvide én fanegruppe på samme tid?"
   }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Skal grupperede faner tælles med"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maksimalt antal taggrupper"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maximale Anzahl an Tag-Gruppen"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Gesamtzahl der Tag-Gruppen begrenzen?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Nur eine Tab-Gruppe gleichzeitig erweitern?"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Sollen gruppierte Tabs gezählt werden"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maximale Anzahl an Tag-Gruppen"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Μέγιστος αριθμός ομάδων ετικετών"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Να περιοριστεί ο συνολικός αριθμός ομάδων ετικετών;"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Ανάπτυξη μόνο μιας ομάδας καρτελών ταυτόχρονα;"
   }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Να συμπεριληφθούν οι ομαδοποιημένες καρτέλες"
+  },
+  "string_for_groupsLimit": {
+    "message": "Μέγιστος αριθμός ομάδων ετικετών"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -57,6 +57,12 @@
   },
   "string_for_groupsLimit": {
     "message": "The upper limit of the number of label groups"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "limit the total number of tag groups?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "expand only one tab group at a time?"
   }
 
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -56,7 +56,7 @@
     "message": "count grouped tabs"
   },
   "string_for_groupsLimit": {
-    "message": "The upper limit of the number of label groups"
+    "message": "The upper limit of the number of tab groups"
   },
   "string_for_countGroupsSwitch": {
     "message": "limit the total number of tag groups?"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -54,5 +54,9 @@
 
   "string_for_countGroupedTabs": {
     "message": "count grouped tabs"
+  },
+  "string_for_groupsLimit": {
+    "message": "The upper limit of the number of label groups"
   }
+
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Contar pestañas agrupadas"
+  },
+  "string_for_groupsLimit": {
+    "message": "Número máximo de grupos de etiquetas"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Número máximo de grupos de etiquetas"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "¿Limitar el número total de grupos de etiquetas?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "¿Expandir solo un grupo de pestañas al mismo tiempo?"
   }
 }

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maksimaalne sildirühmade arv"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Kas piirata sildirühmade koguarvu?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Kas laiendada ainult ühte vahelehtede rühma korraga?"
   }
 }

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Kas arvesse võetakse rühmitatud kaardid"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maksimaalne sildirühmade arv"
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Tagiryhmien enimmäismäärä"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Rajoitatko tunnisteryhmien kokonaismäärää?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Laajennataanko vain yksi välilehtiryhmä samanaikaisesti?"
   }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Lasketaanko ryhmitellyt välilehdet mukaan"
+  },
+  "string_for_groupsLimit": {
+    "message": "Tagiryhmien enimmäismäärä"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -52,9 +52,9 @@
   },
 
   "string_for_countGroupedTabs": {
-    "message": "Faut-il compter les onglets groupés"
+    "message": "Limiter le nombre total de groupes de balises ?"
   },
   "string_for_groupsLimit": {
-    "message": "Nombre maximum de groupes de balises"
+    "message": "Développer un seul groupe d'onglets à la fois ?"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Faut-il compter les onglets groupés"
+  },
+  "string_for_groupsLimit": {
+    "message": "Nombre maximum de groupes de balises"
   }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "A címkecsoportok maximális száma"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Korlátozza a címkecsoportok számát?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Egyszerre csak egy lapcsoportot szeretne kibővíteni?"
   }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Számítsa a csoportosított lapokat"
+  },
+  "string_for_groupsLimit": {
+    "message": "A címkecsoportok maximális száma"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Calcolare le schede raggruppate"
+  },
+  "string_for_groupsLimit": {
+    "message": "Numero massimo di gruppi di tag"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Numero massimo di gruppi di tag"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Limitare il numero totale di gruppi di tag?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Espandere un solo gruppo di schede contemporaneamente?"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "タググループの最大数"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "タググループの総数を制限しますか?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "同時に展開できるタブ グループは 1 つだけですか?"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "グループ化されたタブを計算しますか"
+  },
+  "string_for_groupsLimit": {
+    "message": "タググループの最大数"
   }
 }

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -55,5 +55,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maksimālais tagu grupu skaits"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Vai ierobežot kopējo tagu grupu skaitu?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Vai vienlaikus paplašināt tikai vienu ciļņu grupu?"
   }
 }

--- a/_locales/lv/messages.json
+++ b/_locales/lv/messages.json
@@ -50,8 +50,10 @@
   "string_for_countPinnedTabs": {
     "message": "Vai aprēķināt fiksētās cilnes"
   },
-
   "string_for_countGroupedTabs": {
     "message": "Vai aprēķināt grupētās cilnes"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maksimālais tagu grupu skaits"
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -50,8 +50,10 @@
   "string_for_countPinnedTabs": {
     "message": "Berekent u de vastgezette tabbladen"
   },
-
   "string_for_countGroupedTabs": {
     "message": "Berekent u de gegroepeerde tabbladen"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maximum aantal taggroepen"
   }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -55,5 +55,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maximum aantal taggroepen"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Het totale aantal taggroepen beperken?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Slechts één tabbladgroep tegelijk uitbreiden?"
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Czy obliczać karty zgrupowane"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maksymalna liczba grup tagów"
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maksymalna liczba grup tagów"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Ograniczyć całkowitą liczbę grup tagów?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Rozwinąć tylko jedną grupę kart jednocześnie?"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Calcular as guias agrupadas"
+  },
+  "string_for_groupsLimit": {
+    "message": "Número máximo de grupos de tags"
   }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Número máximo de grupos de tags"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Limitar o número total de grupos de tags?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Expandir apenas um grupo de guias ao mesmo tempo?"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Максимальное количество групп тегов"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Ограничить общее количество групп тегов?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Развернуть только одну группу вкладок одновременно?"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Рассчитать группированные вкладки"
+  },
+  "string_for_groupsLimit": {
+    "message": "Максимальное количество групп тегов"
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -53,5 +53,8 @@
 
   "string_for_countGroupedTabs": {
     "message": "Beräkna grupperade flikar"
+  },
+  "string_for_groupsLimit": {
+    "message": "Maximalt antal tagggrupper"
   }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -56,5 +56,11 @@
   },
   "string_for_groupsLimit": {
     "message": "Maximalt antal tagggrupper"
+  },
+  "string_for_countGroupsSwitch": {
+    "message": "Begränsa det totala antalet tagggrupper?"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "Vill du bara utöka en flikgrupp samtidigt?"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -54,5 +54,11 @@
 
   "string_for_countGroupedTabs": {
     "message": "是否计算已分组标签页"
+  },
+  "string_for_groupsLimit": {
+    "message": "标签组数的上限"
+  },
+  "string_for_countGroupsswitch": {
+    "message": "是否限制标签组"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -58,7 +58,10 @@
   "string_for_groupsLimit": {
     "message": "标签组数的上限"
   },
-  "string_for_countGroupsswitch": {
-    "message": "是否限制标签组"
+  "string_for_countGroupsSwitch": {
+    "message": "是否限制标签组的总数"
+  },
+  "string_for_expand1GroupOnly": {
+    "message": "是否同时只展开一个标签组"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "0.3.2",
+  "version": "0.3.7",
   "author": "Fernando Dilland & Hydrowood",
   "homepage_url": "https://github.com/fernandodilland/allowed-tabs",
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDesc__",
   "default_locale": "en",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Fernando Dilland & Hydrowood",
   "homepage_url": "https://github.com/fernandodilland/allowed-tabs",
 

--- a/static/background.js
+++ b/static/background.js
@@ -65,7 +65,7 @@ const detectTooManyTabsInTotal = options => new Promise(res => {
 
 
 async function detectTooManyGroups(options) {
-    // 获取选项
+    // get options
     const options2 = await getOptions();
     if(!options2.countGroupsSwitch) { return new Promise(() => {});  }
 
@@ -190,7 +190,7 @@ let passes = 0;
 
 const handleExceedTabs = (tab, options, place) => {
     console.log(place)
-    if (options.exceedTabNewWindow && place === "window") { //Fernando留的坑,place上下文还没写下去,业务逻辑应该是大于单页小于多页面
+    if (options.exceedTabNewWindow && place === "window") { ////The pit left by Fernando, the place context has not been written yet, the business logic should be larger than a single page and smaller than multiple pages.
 		browser.windows.create({ tabId: tab.id, focused: true }).catch(console.error);
     } else {
 		const removeTab = () => {
@@ -198,7 +198,7 @@ const handleExceedTabs = (tab, options, place) => {
 			// ForcedAlertTabId = null;
             }).catch((error) => {
                 if (error.message === "Tabs cannot be edited right now (user may be dragging a tab).") {  // maybe different in Chrome or Firefox
-                    // 如果标签页正在被拖动，延迟100毫秒后再次尝试删除
+                    // If the tab is being dragged, try deleting it again after a 100 millisecond delay.
                     setTimeout(removeTab, 100);
                 } else {
                     console.error(error);
@@ -210,7 +210,7 @@ const handleExceedTabs = (tab, options, place) => {
 }
 
 const handleTabCreated = tab => async options => {
-    // 在这里调用 collapseGroup
+    // collapseGroup is called here
     await app.collapseGroup(tab);
 	return Promise.race([
 		detectTooManyTabsInWindow(options),
@@ -301,7 +301,7 @@ const app = {
 	},
 
 	collapseGroup: async function (activeInfo) {
-		// 获取选项
+		// get options
 		const options = await getOptions();
 		if(!options.expand1GroupOnly) { return; }
 	

--- a/static/background.js
+++ b/static/background.js
@@ -20,24 +20,29 @@ getGroupsCount()
 
 const updateBadge = options => {
 	if (!options.displayBadge) {
-		browser.action.setBadgeText({
-		text: "" })
+		browser.action.setBadgeText({ text: "" })
 		return;
 	}
-
 	Promise.all([windowRemaining(options), totalRemaining(options)])
-    .then(remaining => {
+    .then(async remaining => {
         let text1 = Math.min(...remaining).toString();
-        return groupsRemaining(options)
-            .then(remainingGroups => {
-                let text2 = remainingGroups.toString();
-                browser.action.setBadgeText({
-                    text: text1 + '|' + text2
-                });
-                browser.action.setBadgeBackgroundColor({
-                    color: "#7e7e7e"
-                })
-            });
+        const remainingGroups = await groupsRemaining(options)
+		// Check if countGroupsSwitch is enabled
+		if (options.countGroupsSwitch) {
+			const remainingGroups = await groupsRemaining(options)
+			let text2 = remainingGroups.toString()
+			browser.action.setBadgeText({
+				text: text1 + '|' + text2
+			})
+		} else {
+			// If countGroupsSwitch is disabled, display only text1
+			browser.action.setBadgeText({
+				text: text1 
+			})
+		}
+		browser.action.setBadgeBackgroundColor({
+			color: "#7e7e7e"
+		})
     })
 }
 

--- a/static/options.css
+++ b/static/options.css
@@ -190,3 +190,11 @@ h1 {
 }
 
 .hidden { display: none; }
+
+
+#countGroupsSwitch:not(:checked) ~ .parent > #maxGroupsWrap {
+	display: none;
+}
+#countGroupsSwitch:checked ~ .parent > #maxGroupsWrap {
+	display: block; 
+}

--- a/static/options.html
+++ b/static/options.html
@@ -11,8 +11,8 @@
 <body>
 	<!-- Header -->
 	&nbsp;
-	<div class="header">
-	<h1 align="center">__MSG_extensionName__</h1>
+	<div class="header" style="text-align: center;">
+		<h1>__MSG_extensionName__</h1>
 	</div>
 	<div id="options">
 
@@ -20,7 +20,7 @@
 		&nbsp;
 		<div class="parent">
 		<div class="specs">
-			<input id="maxTotal" type="number" min="1" max="99" style="width: 3em">
+			<input id="maxTotal" type="number" min="1" max="999" style="width: 3em">
 		</div>
 		<div class="specs2">
 			<label for="maxTotal">> __MSG_string_1__</label>
@@ -30,7 +30,7 @@
 		<!-- Input 2 -->
 		<div class="parent">
 		<div class="specs">
-			<input id="maxWindow" type="number" min="1" max="99" style="width: 3em">
+			<input id="maxWindow" type="number" min="1" max="999" style="width: 3em">
 		</div>
 		<div class="specs2">
 			<label for="maxTotal">> __MSG_string_2__</label>
@@ -88,8 +88,20 @@
 			</div>
 		</div>
 
-		<!-- Input 3 -->
+		&nbsp;
+
 		<div class="parent">
+			<div class="specs">
+				<label class="switch">
+				<input id="countGroupsSwitch" type="checkbox" checked>
+				<span class="slider round"></span>
+			</div>
+			<div class="specs2">
+				<label class="text_custom" for="countGroupsSwitch" id="countGroupsSwitchLabel">__MSG_string_for_countGroupsSwitch__</label>
+			</div>
+		</div>
+
+		<div id="maxGroupsWrap" class="parent">
 			<div class="specs">
 				<input id="maxGroups" type="number" min="1" max="99" style="width: 3em">
 			</div>
@@ -99,6 +111,19 @@
 			</div>
 		</div>
 
+		&nbsp;
+
+		<div class="parent">
+		<div class="specs">
+			<label class="switch">
+			<input id="expand1GroupOnly" type="checkbox" checked>
+			<span class="slider round"></span>
+		</div>
+		<div class="specs2">
+			<label class="text_custom" for="expand1GroupOnly" id="expand1GroupOnlyLabel">__MSG_string_for_expand1GroupOnly__</label>
+		</div>
+		</div>
+
 		<!-- Place to write the alert message -->
 		<input id="alertMessage" type="text">
 
@@ -106,7 +131,7 @@
 		<p id="status">__MSG_string_8__</p>
 
 		<!-- Developer info -->
-		<p id="developer">__MSG_string_10__: <a id="developer"; href="https://github.com/fernandodilland" target="_blank">Fernando Dilland</a> & <a id="developer"; href="https://github.com/king0billy" target="_blank">king liam</a>.</p>
+		<p id="developer">__MSG_string_10__: <a id="developer"; href="https://github.com/fernandodilland" target="_blank">Fernando Dilland</a> & <a id="developer"; href="https://github.com/king0billy" target="_blank">HydroWood0</a>.</p>
 	</div>
 	<script src="managerLanguage.js"></script>
 </body>

--- a/static/options.html
+++ b/static/options.html
@@ -88,6 +88,17 @@
 			</div>
 		</div>
 
+		<!-- Input 3 -->
+		<div class="parent">
+			<div class="specs">
+				<input id="maxGroups" type="number" min="1" max="99" style="width: 3em">
+			</div>
+			<div class="specs2">
+				<label for="maxGroupsLimit">> __MSG_string_for_groupsLimit__</label>    
+				<span id="groupsCount"></span>
+			</div>
+		</div>
+
 		<!-- Place to write the alert message -->
 		<input id="alertMessage" type="text">
 

--- a/static/options.js
+++ b/static/options.js
@@ -138,22 +138,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		}, 2000);
 	}
 
-	// 获取checkbox和要显示/隐藏的元素
+	// Get the checkbox and elements to show/hide
 	var checkbox = document.getElementById('countGroupsSwitch');
 	var displayElement = document.getElementById('maxGroupsWrap');
 
-	// 设置一个事件监听器来检查checkbox的状态
 	checkbox.addEventListener('change', function() {
 		if(this.checked) {
-			// 如果checkbox被选中，显示元素
 			displayElement.style.display = 'block';
 		} else {
-			// 如果checkbox未被选中，隐藏元素
 			displayElement.style.display = 'none';
 		}
 	});
 
-	// 初始设置 //和html同步也没用
 	if(checkbox.checked) { 
 		displayElement.style.display = 'block'; 
 	} else {

--- a/static/options.js
+++ b/static/options.js
@@ -36,9 +36,19 @@ const updateBadge = options => {
         let text1 = Math.min(...remaining).toString();
         const remainingGroups = await groupsRemaining(options)
 		let text2 = remainingGroups.toString()
-		browser.action.setBadgeText({
-			text: text1 + '|' + text2
-		})
+		// Check if countGroupsSwitch is enabled
+		if (options.countGroupsSwitch) {
+			const remainingGroups = await groupsRemaining(options)
+			let text2 = remainingGroups.toString()
+			browser.action.setBadgeText({
+				text: text1 + '|' + text2
+			})
+		} else {
+			// If countGroupsSwitch is disabled, display only text1
+			browser.action.setBadgeText({
+				text: text1 
+			})
+		}
 		browser.action.setBadgeBackgroundColor({
 			color: "#7e7e7e"
 		})
@@ -97,6 +107,9 @@ const restoreOptions = () => {
 		 document.getElementById('groupedTabsCount').innerText = options.groupedTabsCount;
 		 document.getElementById('groupsCount').innerText = options.groupsCount;
 
+		 const countGroupsSwitch = document.getElementById('countGroupsSwitch');
+		 countGroupsSwitch.dispatchEvent(new Event('change'));
+		 
 		});
 	});
 }
@@ -124,4 +137,27 @@ document.addEventListener('DOMContentLoaded', () => {
 			localStorage.setItem('readMessage', true)
 		}, 2000);
 	}
+
+	// 获取checkbox和要显示/隐藏的元素
+	var checkbox = document.getElementById('countGroupsSwitch');
+	var displayElement = document.getElementById('maxGroupsWrap');
+
+	// 设置一个事件监听器来检查checkbox的状态
+	checkbox.addEventListener('change', function() {
+		if(this.checked) {
+			// 如果checkbox被选中，显示元素
+			displayElement.style.display = 'block';
+		} else {
+			// 如果checkbox未被选中，隐藏元素
+			displayElement.style.display = 'none';
+		}
+	});
+
+	// 初始设置 //和html同步也没用
+	if(checkbox.checked) { 
+		displayElement.style.display = 'block'; 
+	} else {
+		displayElement.style.display = 'none';
+	}
 });
+

--- a/static/options.js
+++ b/static/options.js
@@ -30,12 +30,10 @@ const updateBadge = options => {
 		browser.action.setBadgeText({ text: "" })
 		return;
 	}
-
 	Promise.all([windowRemaining(options), totalRemaining(options)])
     .then(async remaining => {
         let text1 = Math.min(...remaining).toString();
         const remainingGroups = await groupsRemaining(options)
-		let text2 = remainingGroups.toString()
 		// Check if countGroupsSwitch is enabled
 		if (options.countGroupsSwitch) {
 			const remainingGroups = await groupsRemaining(options)


### PR DESCRIPTION
`2024-06`
- Fix extension's collapse after draging while handling exceeded tag(mainly caused by touchpad).
- Add 2 buttons about tab groups. 
- only tested via Edge, never via Chrome （cannot work in Firefox bcz serverworker is not supported in Firefox）.  

`2024-05`
- Forcing an upper limit on the number of tag groups.
- Auto-collapse any other groups when focous on one group.

`2024-02`
- Add pinned & grouped support
- Update Manifest to V3.
- Change all "chrome." to "chrome.||browser." to fit Firefox(no test yet)
- Change "window.alert" to "window.confirm" (some URL like chrome:// and extension store, as well as switching active tabs won't show confirm window and close tab immediately)
- some errors is uncaught or showing up, but don't affect the extension's function